### PR TITLE
docs: add foundational migration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
 # Voca-IA
+
+Plataforma de orientación vocacional enfocada en comunidad educativa.
+
+## Estado del proyecto
+
+- **Estado actual (implementado):** frontend en React + Vite (`client/`) y API en Flask (`server/`).
+- **Dirección arquitectónica definida:** migración directa a **Next.js + Route Handlers serverless en Vercel** (sin DB obligatoria en v1).
+
+La documentación de producto/arquitectura ya está creada para guiar la migración.
+
+## Documentación esencial
+
+- [`docs/prd.md`](docs/prd.md) — PRD ligero v1 (objetivos, alcance, KPIs, riesgos)
+- [`docs/adr/001-nextjs-serverless-v1.md`](docs/adr/001-nextjs-serverless-v1.md) — decisión arquitectónica principal
+- [`docs/spec-migracion-next.md`](docs/spec-migracion-next.md) — plan técnico por fases
+- [`docs/api-contract.md`](docs/api-contract.md) — contrato API canónico v1
+- [`docs/dod-release-checklist.md`](docs/dod-release-checklist.md) — Definition of Done + checklist de release
+
+## Flujo funcional actual
+
+1. `Home` → inicio del quiz
+2. `Questions` → fase general por ramas
+3. Evaluación de ramas:
+   - rama única, o
+   - empate de ramas (desempate)
+4. Evaluación de carreras
+5. `Results` → carrera sugerida o empate de carreras
+
+## Estructura del repositorio
+
+```txt
+Voca-IA/
+├─ client/   # Frontend React + Vite (estado actual)
+├─ server/   # API Flask (estado actual)
+└─ docs/     # Documentación guía para migración a Next.js
+```
+
+## Desarrollo local (estado actual)
+
+### Frontend
+
+```bash
+cd client
+npm install
+npm run dev
+```
+
+### Backend
+
+```bash
+cd server
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python app.py
+```
+
+## Principios de v1 (migración)
+
+- Sin autenticación obligatoria
+- Sin base de datos obligatoria
+- Dominio de negocio desacoplado del transporte HTTP
+- Contratos API claros y tipados
+- Despliegue simple en Vercel
+
+## Próximo hito
+
+Iniciar la reescritura directa a Next.js según `docs/spec-migracion-next.md`, siguiendo los criterios de `docs/dod-release-checklist.md`.

--- a/docs/adr/001-nextjs-serverless-v1.md
+++ b/docs/adr/001-nextjs-serverless-v1.md
@@ -1,0 +1,56 @@
+# ADR 001: Reescritura a Next.js App Router + Route Handlers Serverless en Vercel
+
+## Estado
+Accepted
+
+## Fecha
+2026-04-22
+
+## Contexto
+Voca-IA necesitaba consolidar frontend y backend en una arquitectura simple de operar y desplegar. La base anterior con separación de frontend (Vite) y backend (Flask) introducía fricción operativa: CORS, despliegues desacoplados, doble observabilidad y mayor superficie de configuración en ambientes.
+
+Para v1, el objetivo principal es entregar valor rápido con una plataforma mantenible, con bajo costo operativo y sin imponer una base de datos como prerequisito. El alcance funcional inicial puede operar con servicios externos y/o almacenamiento efímero según caso de uso.
+
+## Decisión
+Se adopta una reescritura directa a **Next.js con App Router** y **Route Handlers serverless** desplegados en **Vercel** como arquitectura principal de v1.
+
+Esta decisión implica:
+- Unificar UI y API en un mismo repositorio y runtime de despliegue.
+- Implementar endpoints backend en Route Handlers (`app/api/**/route.ts`) serverless.
+- Estandarizar rutas API canónicas en **kebab-case** (`/api/preguntas-generales`, `/api/evaluar-ramas`, `/api/evaluar-carrera`).
+- Mantener la **lógica de dominio desacoplada del transporte HTTP** (casos de uso y servicios de dominio independientes de `Request`/`Response`).
+- No requerir base de datos obligatoria en v1; la persistencia se define por necesidad funcional puntual.
+
+## Alternativas consideradas
+1. **Mantener Vite + Flask**  
+   Se descarta porque mantiene dos stacks operativos, configuración de CORS entre orígenes y pipelines de despliegue separados.
+
+2. **Vite + Vercel Functions**  
+   Se descarta porque reduce parte de la operación, pero conserva la fragmentación entre frontend y backend, además de límites de consistencia arquitectónica entre proyectos.
+
+3. **Next.js full static (sin Route Handlers)**  
+   Se descarta porque no cubre necesidades de lógica server-side para integraciones y orquestación de requests en v1.
+
+## Consecuencias positivas
+- Se elimina la fricción de CORS al unificar frontend y API bajo el mismo dominio/plataforma.
+- Se simplifica el deploy en Vercel con un único pipeline y configuración centralizada.
+- Se reduce el overhead operativo (menos servicios, menos observabilidad distribuida, menos puntos de falla).
+- Se acelera la entrega de funcionalidades al compartir tipado, utilidades y convenciones en un solo codebase.
+
+## Consecuencias negativas / trade-offs
+- Mayor acoplamiento estratégico al ecosistema Next.js/Vercel.
+- Restricciones del modelo serverless (cold starts, límites de ejecución y de entorno).
+- Necesidad de disciplina arquitectónica para evitar mezclar dominio con capa HTTP en Route Handlers.
+
+## Plan de mitigación
+- Diseñar la aplicación con capas explícitas: `domain`/`application` separadas de `infrastructure/http`.
+- Definir contratos de puertos/adaptadores para aislar proveedores externos y facilitar migración futura.
+- Monitorear latencia, errores y tiempos de arranque en funciones serverless con alertas tempranas.
+- Documentar guías de implementación para Route Handlers que prohíban lógica de negocio en handlers.
+
+## Revisión futura (triggers para reevaluar)
+Esta decisión se reevaluará si ocurre cualquiera de estos triggers:
+- Requisito de procesamiento de larga duración incompatible con límites serverless.
+- Necesidad sostenida de workloads stateful que justifiquen infraestructura dedicada.
+- Incremento de costo/latencia en Vercel por encima de umbrales definidos por producto.
+- Exigencias de compliance o residencia de datos que requieran control infra más estricto.

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,0 +1,172 @@
+# Voca-IA — Contrato API canónico (v1)
+
+> Fuente única de verdad para rutas y payloads durante la migración a Next.js serverless.
+
+## Convenciones
+
+- Base path: `/api`
+- Naming de rutas: **kebab-case**
+- `Content-Type`: `application/json`
+- Codificación de respuestas de quiz: `"sí" | "no"`
+
+## Endpoints canónicos
+
+1. `GET /api/preguntas-generales`
+2. `POST /api/evaluar-ramas`
+3. `POST /api/evaluar-carrera`
+
+---
+
+## 1) GET `/api/preguntas-generales`
+
+### Response 200
+
+```json
+{
+  "Ingeniería y Ciencias Físico Matemáticas": ["..."],
+  "Ciencias Médico Biológicas": ["..."],
+  "Ciencias Sociales y Administrativas": ["..."]
+}
+```
+
+### Errores
+
+- `500` si ocurre fallo interno inesperado.
+
+---
+
+## 2) POST `/api/evaluar-ramas`
+
+### Request
+
+```json
+{
+  "Ingeniería y Ciencias Físico Matemáticas_0": "sí",
+  "Ciencias Médico Biológicas_1": "no"
+}
+```
+
+### Reglas de validación
+
+- Valores permitidos: `"sí" | "no"`
+- Keys con patrón `<rama>_<indice>`
+
+### Response 200 — rama elegida
+
+```json
+{
+  "status": "rama_elegida",
+  "rama_sugerida": "Ingeniería y Ciencias Físico Matemáticas",
+  "preguntas_carreras": {
+    "Ingeniería en Sistemas Computacionales": ["..."],
+    "Ingeniería Industrial": ["..."]
+  }
+}
+```
+
+### Response 200 — empate de ramas
+
+```json
+{
+  "status": "empate_ramas_desempate",
+  "ramas_sugeridas": [
+    "Ingeniería y Ciencias Físico Matemáticas",
+    "Ciencias Médico Biológicas"
+  ],
+  "message": "Mostraste el mismo nivel de interés por varias áreas...",
+  "preguntas_para_desempate": {
+    "Ingeniería y Ciencias Físico Matemáticas": {
+      "Ingeniería en Sistemas Computacionales": ["..."]
+    },
+    "Ciencias Médico Biológicas": {
+      "Médico Cirujano y Partero": ["..."]
+    }
+  }
+}
+```
+
+### Errores
+
+- `400` payload faltante/inválido
+- `422` estructura inválida
+- `500` fallo interno
+
+---
+
+## 3) POST `/api/evaluar-carrera`
+
+### Request — contexto de rama específica
+
+```json
+{
+  "rama": "Ingeniería y Ciencias Físico Matemáticas",
+  "respuestas": {
+    "Ingeniería en Sistemas Computacionales_0": "sí",
+    "Ingeniería Industrial_1": "no"
+  }
+}
+```
+
+### Request — contexto de desempate
+
+```json
+{
+  "ramas_desempate": [
+    "Ingeniería y Ciencias Físico Matemáticas",
+    "Ciencias Médico Biológicas"
+  ],
+  "respuestas": {
+    "Ingeniería en Sistemas Computacionales_0": "sí",
+    "Médico Cirujano y Partero_1": "sí"
+  }
+}
+```
+
+### Response 200 — resultado final
+
+```json
+{
+  "status": "resultado_final",
+  "rama_sugerida": "Ingeniería y Ciencias Físico Matemáticas",
+  "carreras_sugeridas": ["Ingeniería en Sistemas Computacionales"],
+  "message": "La carrera que más se ajusta a tus intereses es:"
+}
+```
+
+### Response 200 — empate de carrera
+
+```json
+{
+  "status": "empate_carrera",
+  "rama_sugerida": "Múltiples Ramas",
+  "carreras_sugeridas": ["Carrera A", "Carrera B"],
+  "message": "Has mostrado el mismo interés por varias carreras..."
+}
+```
+
+### Response 200 — sin carreras evaluadas
+
+```json
+{
+  "status": "no_carreras_evaluadas",
+  "message": "No se pudieron evaluar carreras con los datos proporcionados."
+}
+```
+
+### Errores
+
+- `400` contexto faltante o payload inválido
+- `422` estructura inválida
+- `500` fallo interno
+
+---
+
+## Compatibilidad legacy (temporal)
+
+Durante migración, se permite alias temporal para rutas legacy Flask:
+
+- `/api/preguntas_generales`
+- `/api/evaluar_ramas`
+- `/api/evaluar_carrera`
+
+La versión canónica para desarrollo nuevo y documentación es la de kebab-case.

--- a/docs/dod-release-checklist.md
+++ b/docs/dod-release-checklist.md
@@ -1,0 +1,106 @@
+# Voca-IA MVP (Next.js) — Definition of Done + Release Checklist
+
+> Documento operativo para cierre de tareas/hitos del MVP migrado a Next.js.
+
+## 1) Definition of Done (producto)
+
+- [ ] El flujo vocacional completo funciona de punta a punta en producción:
+  - [ ] Inicio en `/` (landing) con CTA funcional hacia `/questions`.
+  - [ ] Cuestionario en `/questions` carga preguntas y permite responder Sí/No.
+  - [ ] Resultado en `/results` muestra recomendación final o empate.
+- [ ] Estados funcionales del motor vocacional validados:
+  - [ ] `rama_elegida` (pasa a preguntas específicas de rama).
+  - [ ] `empate_ramas_desempate` (activa preguntas de desempate entre ramas).
+  - [ ] `resultado_final` (una carrera ganadora).
+  - [ ] `empate_carrera` (múltiples carreras empatadas).
+- [ ] Manejo de errores visible y entendible para usuario:
+  - [ ] Error al cargar preguntas generales.
+  - [ ] Error al evaluar ramas.
+  - [ ] Error al evaluar carrera.
+  - [ ] Acceso directo a `/results` sin estado muestra fallback y CTA de reinicio.
+- [ ] Copys críticos revisados (sin mensajes ambiguos, sin placeholders de prueba).
+- [ ] No hay regresiones funcionales respecto del alcance MVP aprobado.
+
+## 2) Definition of Done (ingeniería)
+
+- [ ] Rutas migradas a Next.js y consistentes con el flujo esperado (`/`, `/questions`, `/results`).
+- [ ] Integración API operativa con endpoints esperados:
+  - [ ] `GET /api/preguntas-generales`
+  - [ ] `POST /api/evaluar-ramas`
+  - [ ] `POST /api/evaluar-carrera`
+- [ ] Estados y contratos de respuesta controlados en frontend (sin asumir respuestas “felices” únicamente).
+- [ ] Manejo de errores HTTP y de red implementado (mensajes y fallback de UI).
+- [ ] Variables de entorno definidas y documentadas (`.env`/Vercel Environment Variables).
+- [ ] Lint/tests del alcance modificado en verde.
+- [ ] Documentación mínima actualizada:
+  - [ ] README o docs de operación del flujo.
+  - [ ] ADR actualizado si hubo decisión técnica relevante (routing, estado, integración API, despliegue).
+  - [ ] PRD actualizado si cambió alcance funcional/UX del MVP.
+
+## 3) Checklist pre-merge
+
+- [ ] Cambios acotados al objetivo del PR (sin “scope creep”).
+- [ ] Review técnico aprobado (mínimo 1 reviewer).
+- [ ] Conflictos de merge resueltos.
+- [ ] Checklist funcional completado con evidencia (ver sección 7).
+- [ ] Casos críticos verificados manualmente:
+  - [ ] Ruta feliz: preguntas generales → rama específica/desempate → resultado.
+  - [ ] Caso empate de ramas (`empate_ramas_desempate`).
+  - [ ] Caso empate de carrera (`empate_carrera`).
+  - [ ] Recuperación ante error de API/red.
+- [ ] No se agregaron pasos fuera del flujo normal de release.
+
+## 4) Checklist pre-deploy Vercel
+
+- [ ] Proyecto/branch correcto seleccionado para deploy.
+- [ ] Variables de entorno en Vercel validadas (nombres, valores, ambiente).
+- [ ] Dominio/alias objetivo confirmado.
+- [ ] Configuración de runtime y región verificada si aplica.
+- [ ] Deploy Preview validado funcionalmente sobre los 4 estados vocacionales.
+- [ ] Sin errores bloqueantes en logs de build/deploy de Vercel.
+
+## 5) Checklist post-deploy
+
+- [ ] Smoke test productivo en URL final:
+  - [ ] `/` carga y navega.
+  - [ ] `/questions` responde e invoca APIs correctamente.
+  - [ ] `/results` muestra estado esperado y fallback en acceso inválido.
+- [ ] Monitoreo inicial (15–30 min) sin errores críticos (5xx, timeouts, fallos de red).
+- [ ] Verificación de métricas mínimas (error rate, tiempo de respuesta, éxito de flujo).
+- [ ] Confirmación de negocio/producto de que el MVP quedó “usable”.
+
+## 6) Criterios de rollback
+
+Aplicar rollback si ocurre cualquiera de estos eventos en producción:
+
+- [ ] No se puede completar el flujo vocacional end-to-end.
+- [ ] Fallan sistemáticamente endpoints críticos (`/api/preguntas-generales`, `/api/evaluar-ramas`, `/api/evaluar-carrera`).
+- [ ] Error rate crítico sostenido o UX rota (pantallas en blanco, navegación bloqueada).
+- [ ] Datos/estado inconsistente que altera recomendaciones de carrera.
+
+Acción de rollback:
+
+- [ ] Revertir al deployment estable anterior en Vercel.
+- [ ] Comunicar incidente y alcance (producto + ingeniería).
+- [ ] Abrir ticket post-mortem con causa raíz y plan de corrección antes de reintentar release.
+
+## 7) Evidencias mínimas requeridas para cerrar una tarea/hito
+
+- [ ] Link a PR mergeado + descripción de alcance.
+- [ ] Capturas o video corto de:
+  - [ ] Ruta feliz.
+  - [ ] Empate de ramas.
+  - [ ] Empate de carrera.
+  - [ ] Manejo de error/fallback.
+- [ ] Evidencia de validación técnica:
+  - [ ] Resultado de lint/tests relevantes.
+  - [ ] Logs o capturas de Deploy Preview y producción (sin errores críticos).
+- [ ] Evidencia documental:
+  - [ ] README/docs actualizados.
+  - [ ] ADR actualizado (si hubo cambio de decisión técnica).
+  - [ ] PRD actualizado (si cambió alcance funcional).
+- [ ] Criterio de aceptación de producto explícitamente marcado como cumplido.
+
+---
+
+**Regla de oro:** si no hay evidencia verificable, la tarea NO está Done.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,233 @@
+# PRD Voca-IA v1 (ligero y accionable)
+
+## 1) Resumen ejecutivo
+
+Voca-IA v1 se enfocará en entregar una experiencia de orientación vocacional simple, útil y transparente para estudiantes, migrando la app actual (frontend React + backend Flask) a una arquitectura unificada en **Next.js + funciones serverless en Vercel**.
+
+El flujo principal se mantiene sin cambios de negocio: **Home → Questions → Results**, con evaluación por fases:
+
+1. preguntas generales por rama,
+2. evaluación de ramas,
+3. preguntas específicas de carreras (rama elegida o desempate),
+4. resultado final (una o múltiples carreras).
+
+La v1 prioriza velocidad de entrega, bajo costo operativo y despliegue simple. **No habrá autenticación ni base de datos obligatoria en v1**. El sistema operará de forma stateless, con catálogo de preguntas versionado en código y cálculo de resultados en endpoints serverless.
+
+---
+
+## 2) Problema y contexto
+
+### Problema
+Estudiantes adolescentes y jóvenes necesitan una guía inicial para explorar carreras, pero muchas herramientas:
+
+- son opacas (no explican cómo recomiendan),
+- tienen fricción de entrada alta,
+- o no están pensadas para una primera decisión vocacional comunitaria.
+
+### Contexto actual del proyecto
+Voca-IA ya tiene una base funcional:
+
+- Frontend con rutas `"/"`, `"/questions"`, `"/results"`.
+- Backend con API por fases:
+  - `GET /api/preguntas_generales` (legacy Flask)
+  - `POST /api/evaluar_ramas` (legacy Flask)
+  - `POST /api/evaluar_carrera` (legacy Flask)
+- Lógica de desempate entre ramas y entre carreras.
+
+El principal gap de producto/tecnología hoy es la fragmentación de stack (cliente + servidor separados) y la necesidad de simplificar operación/despliegue para escalar validación temprana de producto.
+
+---
+
+## 3) Objetivos de producto (negocio + usuario)
+
+### Objetivos de negocio
+1. Reducir complejidad operativa mediante una única plataforma de despliegue (Vercel).
+2. Lanzar v1 estable en menor tiempo para validar adopción real.
+3. Posicionar Voca-IA como herramienta comunitaria de orientación vocacional clara y confiable.
+
+### Objetivos de usuario
+1. Completar el quiz de forma fluida, sin registro obligatorio.
+2. Obtener recomendaciones comprensibles (rama/carreras) en pocos minutos.
+3. Entender que el resultado es orientativo y transparente, no una “caja negra”.
+
+---
+
+## 4) Público objetivo (primario/secundario)
+
+### Primario
+- Estudiantes de secundaria/preparatoria (15-19) que buscan primera orientación vocacional.
+
+### Secundario
+- Docentes, orientadores y familias que acompañan decisiones educativas.
+- Comunidad educativa que necesita una herramienta rápida para iniciar conversaciones vocacionales.
+
+---
+
+## 5) Alcance v1 (in-scope / out-of-scope)
+
+### In-scope v1
+- Migración del flujo actual a Next.js (App Router) con páginas equivalentes:
+  - `/` (home)
+  - `/questions`
+  - `/results`
+- Implementación de API serverless equivalente a la lógica actual:
+  - `GET /api/preguntas-generales`,
+  - `POST /api/evaluar-ramas`,
+  - `POST /api/evaluar-carrera`.
+- Conservación de estados de respuesta del usuario en cliente (memoria local durante sesión).
+- Mensajería clara de resultado orientativo y explicabilidad básica del proceso.
+- Deploy único en Vercel.
+
+### Out-of-scope v1
+- **Autenticación (login/registro).**
+- **Base de datos obligatoria** para operación principal.
+- Historial persistente de resultados por usuario.
+- Panel administrativo completo.
+- Personalización avanzada por perfil/escuela.
+- Integraciones externas (CRM, LMS, WhatsApp, etc.).
+
+---
+
+## 6) Requisitos funcionales (priorizados MoSCoW)
+
+### Must Have
+1. El usuario puede iniciar en Home y avanzar al quiz con CTA principal.
+2. El sistema presenta preguntas generales por rama y registra respuestas “sí/no”.
+3. Al terminar preguntas generales, el sistema evalúa puntajes por rama:
+   - si hay una rama ganadora: pasa a preguntas de carrera de esa rama,
+   - si hay empate de ramas: activa fase de desempate con preguntas de carreras de ramas empatadas.
+4. Al terminar preguntas de carrera, el sistema entrega resultado:
+   - carrera única sugerida, o
+   - empate de carreras (lista de opciones).
+5. La vista de resultados muestra rama sugerida (cuando aplique), lista de carreras y mensaje orientativo.
+6. Manejo básico de errores de red/API con mensajes comprensibles.
+
+### Should Have
+1. Reinicio del quiz desde resultados.
+2. Indicador de progreso visible durante preguntas.
+3. Copy de transparencia: “resultado orientativo basado en tus respuestas”.
+4. Validación de payload en endpoints serverless para evitar respuestas inválidas.
+
+### Could Have
+1. Versión de contenido informativo breve por carrera (descripción corta).
+2. Evento analítico básico (inicio, finalización, tipo de resultado).
+
+### Won’t Have (v1)
+1. Registro/login.
+2. Persistencia obligatoria en DB.
+3. Recomendaciones con modelos ML externos.
+
+---
+
+## 7) Requisitos no funcionales
+
+### Performance
+- TTI percibido en Home/Questions aceptable en red móvil promedio.
+- Respuesta de endpoints de evaluación en latencia baja para mantener continuidad del quiz.
+- Evitar cargas innecesarias de datos: solo traer preguntas requeridas por fase.
+
+### Disponibilidad
+- Despliegue en Vercel con alta disponibilidad base de plataforma.
+- Degradación controlada en caso de error serverless (mensaje claro y opción de reintento).
+
+### Privacidad
+- **Sin auth y sin DB obligatoria en v1**: minimiza recolección de datos personales.
+- No solicitar datos sensibles para completar el quiz.
+- Si se habilitan métricas, usar eventos agregados y no identificables por persona.
+
+### Accesibilidad
+- Navegación básica por teclado en botones principales.
+- Contraste de texto/botones adecuado en vistas clave.
+- Jerarquía semántica mínima de títulos y contenido.
+
+### SEO básico
+- Home indexable con metadata esencial (title/description).
+- Mensaje claro de propósito comunitario de orientación vocacional.
+- Resultados pueden permanecer no indexables si dependen de estado efímero de sesión.
+
+---
+
+## 8) Métricas de éxito (KPI con meta inicial)
+
+1. **Tasa de inicio del quiz** = usuarios que pasan de Home a Questions / visitas a Home.
+   - Meta inicial: **≥ 45%**.
+
+2. **Tasa de finalización del quiz** = usuarios que llegan a Results / usuarios que iniciaron Questions.
+   - Meta inicial: **≥ 65%**.
+
+3. **Tiempo medio de completitud** (inicio Questions → Results).
+   - Meta inicial: **≤ 6 minutos**.
+
+4. **Error rate de API de evaluación** (4xx/5xx sobre requests a endpoints de evaluación).
+   - Meta inicial: **< 2%**.
+
+5. **Porcentaje de sesiones con resultado entregado** (al menos una sugerencia visible).
+   - Meta inicial: **≥ 98%**.
+
+---
+
+## 9) Riesgos, supuestos y dependencias
+
+### Riesgos
+1. Reglas de evaluación rígidas pueden generar percepción de baja personalización.
+2. Sin persistencia, se pierde historial al cerrar sesión/recargar.
+3. Cambios de contenido de preguntas requieren redeploy si están en código.
+
+### Supuestos
+1. Para v1, valor principal está en orientación inicial rápida, no en tracking longitudinal.
+2. El algoritmo actual por puntajes y desempates es suficiente para una primera versión pública.
+3. Comunidad valora transparencia del método por encima de complejidad algorítmica.
+
+### Dependencias
+1. Migración técnica a Next.js 15+ (routing, renderizado y serverless).
+2. Configuración de variables de entorno en Vercel para endpoints internos/externos según implementación.
+3. Definición y curaduría mínima del catálogo de preguntas y carreras (contenido fuente).
+
+---
+
+## 10) Criterios de aceptación v1
+
+Se considera v1 aceptada cuando:
+
+1. El flujo **Home → Questions → Results** funciona de extremo a extremo en producción Vercel.
+2. Existen endpoints serverless equivalentes a:
+   - `GET /api/preguntas-generales`,
+   - `POST /api/evaluar-ramas`,
+   - `POST /api/evaluar-carrera`,
+   con respuestas consistentes con la lógica actual de fases.
+3. Se cubren los tres escenarios de salida:
+   - rama elegida,
+   - empate de ramas con desempate,
+   - empate de carreras / resultado final.
+4. Mensajes de error y estados vacíos no bloquean irreversiblemente el flujo.
+5. El producto comunica explícitamente que:
+   - no reemplaza orientación profesional formal,
+   - el resultado es orientativo,
+   - no requiere login ni base de datos obligatoria en v1.
+
+---
+
+## 11) Roadmap corto (MVP, post-MVP)
+
+### MVP (v1)
+- Migrar frontend actual a Next.js manteniendo UX principal.
+- Portar lógica Flask de evaluación a funciones serverless.
+- Publicar en Vercel con monitoreo básico de errores y KPIs mínimos.
+- Validar uso real con comunidad educativa inicial.
+
+### Post-MVP (v1.x / v2)
+- Instrumentación analítica más robusta para optimizar abandono por fase.
+- Gestión de contenido de preguntas sin redeploy (opcional: JSON remoto o CMS liviano).
+- Exportación/compartido de resultado.
+- Evaluar persistencia opcional (no obligatoria) para historial y seguimiento.
+- Evaluar autenticación solo si habilita un caso de uso claro (seguimiento longitudinal, orientación guiada por tutor).
+
+---
+
+## Decisiones concretas y accionables
+
+1. Mantener algoritmo de puntajes y desempates en v1 para evitar deriva funcional.
+2. Consolidar FE+API en Next.js + Vercel para bajar fricción de operación.
+3. Operar sin auth y sin DB obligatoria en v1 para acelerar salida y reducir riesgos de privacidad.
+4. Priorizar claridad comunitaria: resultados explicados, lenguaje orientativo y expectativas realistas.
+5. Medir conversión y finalización desde el día 1 para decidir evolución post-MVP con evidencia.

--- a/docs/spec-migracion-next.md
+++ b/docs/spec-migracion-next.md
@@ -1,0 +1,427 @@
+# Especificación técnica breve — Migración Voca-IA a Next.js
+
+## 1) Objetivo técnico
+
+Migrar Voca-IA desde arquitectura separada **Vite+React (frontend) + Flask (API)** a una única aplicación **Next.js (App Router)** desplegable en Vercel, manteniendo **paridad funcional completa** del flujo actual:
+
+1. Preguntas generales
+2. Evaluación de ramas
+3. Rama única o desempate entre ramas
+4. Evaluación de carreras
+5. Resultado final (único o empate de carrera)
+
+Objetivos específicos de la migración:
+
+- Consolidar frontend y backend en un solo repositorio/artefacto ejecutable.
+- Mover la lógica de evaluación a un **dominio puro** (sin dependencia de Next/React).
+- Definir contratos de API tipados en **TypeScript** y validados en runtime.
+- Mantener v1 sin base de datos ni autenticación.
+- Preparar base para evolución (persistencia, analytics, auth) sin reescritura mayor.
+
+---
+
+## 2) Estado actual resumido (Vite+React + Flask)
+
+### Frontend actual (Vite + React)
+
+- Cliente en `client/`.
+- Routing con `react-router-dom`:
+  - `/` → Home
+  - `/questions` → flujo de preguntas
+  - `/results` → render de resultado
+- Integración API por `fetch` usando `VITE_API_URL`.
+
+### Backend actual (Flask)
+
+- Servicio en `server/app.py`.
+- Endpoints:
+  - `GET /api/preguntas_generales`
+  - `POST /api/evaluar_ramas`
+  - `POST /api/evaluar_carrera`
+- Lógica embebida en el mismo archivo:
+  - Banco de preguntas generales por rama.
+  - Banco de carreras/preguntas específicas por rama.
+  - Cálculo de puntajes y resolución de empates.
+- CORS explícito para dominios de frontend.
+
+### Restricciones funcionales observadas
+
+- Flujo actual depende de IDs de pregunta tipo `"{rama}_{index}"` y `"{carrera}_{index}"`.
+- Respuestas esperadas como strings (`"sí" | "no"`).
+- Estados de negocio del backend: `rama_elegida`, `empate_ramas_desempate`, `empate_carrera`, `resultado_final`, `no_carreras_evaluadas`.
+
+---
+
+## 3) Arquitectura objetivo (Next App Router + Route Handlers + dominio puro)
+
+### Principios
+
+1. **App Router para UI** (`app/`).
+2. **Route Handlers** para API (`app/api/**/route.ts`).
+3. **Dominio puro** en `src/domain/**`:
+   - Sin imports de `next/*`, `react`, `window` o infraestructura.
+   - Funciones determinísticas, testeables por unit tests.
+4. **Separación por capas**:
+   - `src/domain`: reglas de negocio y tipos del dominio.
+   - `src/application`: casos de uso/orquestación.
+   - `src/infrastructure`: adaptadores (HTTP mapping, catálogos en memoria).
+5. **Tipado + validación runtime**:
+   - TypeScript estricto.
+   - Validación de payloads de entrada/salida con Zod.
+
+### Vista de alto nivel
+
+- UI (Server/Client Components) consume `/api/*` internos de Next.
+- Route Handlers validan request con schema, ejecutan caso de uso y devuelven JSON tipado.
+- Casos de uso invocan dominio puro con catálogo de preguntas en memoria (v1).
+
+---
+
+## 4) Estructura de carpetas objetivo propuesta
+
+```txt
+Voca-IA/
+├─ app/
+│  ├─ page.tsx                     # Home
+│  ├─ questions/page.tsx           # Flujo de preguntas
+│  ├─ results/page.tsx             # Resultado
+│  └─ api/
+│     ├─ preguntas-generales/route.ts
+│     ├─ evaluar-ramas/route.ts
+│     └─ evaluar-carrera/route.ts
+│
+├─ src/
+│  ├─ domain/
+│  │  ├─ entities/
+│  │  │  ├─ rama.ts
+│  │  │  ├─ carrera.ts
+│  │  │  └─ pregunta.ts
+│  │  ├─ services/
+│  │  │  ├─ evaluarRamas.ts
+│  │  │  └─ evaluarCarreras.ts
+│  │  └─ types.ts
+│  │
+│  ├─ application/
+│  │  ├─ use-cases/
+│  │  │  ├─ getPreguntasGenerales.ts
+│  │  │  ├─ postEvaluarRamas.ts
+│  │  │  └─ postEvaluarCarrera.ts
+│  │  └─ contracts.ts
+│  │
+│  ├─ infrastructure/
+│  │  ├─ catalogo/
+│  │  │  └─ preguntasCatalogo.ts   # datos en memoria (v1)
+│  │  └─ http/
+│  │     ├─ schemas.ts             # zod schemas req/res
+│  │     └─ mappers.ts
+│  │
+│  └─ shared/
+│     ├─ result.ts
+│     └─ errors.ts
+│
+├─ tests/
+│  ├─ unit/
+│  │  ├─ evaluarRamas.test.ts
+│  │  └─ evaluarCarreras.test.ts
+│  └─ smoke/
+│     └─ flujo-migracion.smoke.md
+└─ docs/
+   └─ spec-migracion-next.md
+```
+
+Notas:
+
+- v1 mantiene catálogo en memoria para evitar dependencia de DB.
+- No se implementa auth en esta etapa.
+
+---
+
+## 5) Mapeo de endpoints (Flask -> Next Route Handlers)
+
+| Flask actual | Next objetivo | Método | Responsabilidad |
+|---|---|---|---|
+| `/api/preguntas_generales` | `/api/preguntas-generales` | GET | Retornar preguntas generales por rama |
+| `/api/evaluar_ramas` | `/api/evaluar-ramas` | POST | Calcular rama elegida o desempate de ramas |
+| `/api/evaluar_carrera` | `/api/evaluar-carrera` | POST | Calcular carrera(s) sugerida(s) y resultado final |
+
+Decisión de compatibilidad:
+
+- Internamente se usará naming **kebab-case** en rutas Next.
+- Durante transición puede agregarse alias temporal para mantener compatibilidad con cliente legado, pero el contrato canónico será el de rutas nuevas.
+
+---
+
+## 6) Contratos de API (requests/responses esperados)
+
+> Todas las respuestas JSON incluyen `content-type: application/json`.
+> Errores de validación retornan `400` con detalle.
+> Fuente de verdad de contrato canónico: `docs/api-contract.md`.
+
+### 6.1 GET `/api/preguntas-generales`
+
+**Response 200**
+
+```json
+{
+  "Ingeniería y Ciencias Físico Matemáticas": ["..."],
+  "Ciencias Médico Biológicas": ["..."],
+  "Ciencias Sociales y Administrativas": ["..."]
+}
+```
+
+### 6.2 POST `/api/evaluar-ramas`
+
+**Request**
+
+```json
+{
+  "Ingeniería y Ciencias Físico Matemáticas_0": "sí",
+  "Ciencias Médico Biológicas_1": "no"
+}
+```
+
+Reglas:
+
+- Valor permitido por respuesta: `"sí" | "no"`.
+- Keys deben respetar patrón `<rama>_<indice>`.
+
+**Response 200 (rama elegida)**
+
+```json
+{
+  "status": "rama_elegida",
+  "rama_sugerida": "Ingeniería y Ciencias Físico Matemáticas",
+  "preguntas_carreras": {
+    "Ingeniería en Sistemas Computacionales": ["..."],
+    "Ingeniería Industrial": ["..."]
+  }
+}
+```
+
+**Response 200 (empate para desempate)**
+
+```json
+{
+  "status": "empate_ramas_desempate",
+  "ramas_sugeridas": [
+    "Ingeniería y Ciencias Físico Matemáticas",
+    "Ciencias Médico Biológicas"
+  ],
+  "message": "Mostraste el mismo nivel de interés por varias áreas...",
+  "preguntas_para_desempate": {
+    "Ingeniería y Ciencias Físico Matemáticas": {
+      "Ingeniería en Sistemas Computacionales": ["..."]
+    },
+    "Ciencias Médico Biológicas": {
+      "Médico Cirujano y Partero": ["..."]
+    }
+  }
+}
+```
+
+**Response 400**
+
+```json
+{
+  "error": "No se recibieron datos"
+}
+```
+
+### 6.3 POST `/api/evaluar-carrera`
+
+**Request (contexto rama específica)**
+
+```json
+{
+  "rama": "Ingeniería y Ciencias Físico Matemáticas",
+  "respuestas": {
+    "Ingeniería en Sistemas Computacionales_0": "sí",
+    "Ingeniería Industrial_1": "no"
+  }
+}
+```
+
+**Request (contexto desempate)**
+
+```json
+{
+  "ramas_desempate": [
+    "Ingeniería y Ciencias Físico Matemáticas",
+    "Ciencias Médico Biológicas"
+  ],
+  "respuestas": {
+    "Ingeniería en Sistemas Computacionales_0": "sí",
+    "Médico Cirujano y Partero_1": "sí"
+  }
+}
+```
+
+**Response 200 (resultado final)**
+
+```json
+{
+  "status": "resultado_final",
+  "rama_sugerida": "Ingeniería y Ciencias Físico Matemáticas",
+  "carreras_sugeridas": ["Ingeniería en Sistemas Computacionales"],
+  "message": "La carrera que más se ajusta a tus intereses es:"
+}
+```
+
+**Response 200 (empate de carrera)**
+
+```json
+{
+  "status": "empate_carrera",
+  "rama_sugerida": "Múltiples Ramas",
+  "carreras_sugeridas": ["Carrera A", "Carrera B"],
+  "message": "Has mostrado el mismo interés por varias carreras..."
+}
+```
+
+**Response 400 (payload inválido/contexto faltante)**
+
+```json
+{
+  "error": "No se proporcionó contexto de rama o desempate válido"
+}
+```
+
+---
+
+## 7) Plan por fases con Definition of Done
+
+### Fase 1 — Base Next + dominio tipado
+
+**Alcance**
+
+- Crear app Next con App Router y TypeScript strict.
+- Portar catálogos (preguntas/ramas/carreras) a `src/infrastructure/catalogo`.
+- Implementar dominio puro (`evaluarRamas`, `evaluarCarreras`) + unit tests.
+
+**DoD**
+
+- Build local en modo desarrollo funciona.
+- Unit tests de dominio en verde.
+- Sin imports de Next/React dentro de `src/domain`.
+
+### Fase 2 — API Route Handlers con validación
+
+**Alcance**
+
+- Implementar `/api/preguntas-generales`, `/api/evaluar-ramas`, `/api/evaluar-carrera`.
+- Validar requests con Zod.
+- Mapear errores de validación a `400`.
+
+**DoD**
+
+- Contratos JSON cumplen ejemplos definidos.
+- Casos inválidos devuelven errores consistentes.
+- Paridad de estados de negocio con Flask.
+
+### Fase 3 — Migración UI del flujo completo
+
+**Alcance**
+
+- Migrar páginas Home / Questions / Results a `app/**`.
+- Adaptar llamadas a nueva API interna (sin `VITE_API_URL`).
+- Conservar comportamiento UX del flujo actual.
+
+**DoD**
+
+- Flujo completo ejecutable end-to-end.
+- Se mantiene secuencia general → rama/tie-break → resultado.
+- No hay regresiones funcionales visibles en flujo core.
+
+### Fase 4 — Hardening + deploy
+
+**Alcance**
+
+- Smoke tests manuales/e2e básicos.
+- Configuración Vercel (preview + production).
+- Documentación operativa y rollback.
+
+**DoD**
+
+- Preview deployment validado.
+- Producción estable con monitoreo básico de errores.
+- Rollback documentado y probado en simulación.
+
+---
+
+## 8) Riesgos técnicos y mitigación
+
+1. **Riesgo: ruptura de contrato por cambio de naming en rutas**
+   - Mitigación: tabla de mapeo + alias temporal + tests de contrato.
+
+2. **Riesgo: diferencias en parsing/encoding de keys con acentos y espacios**
+   - Mitigación: esquema de IDs estable, helper centralizado para construir/leer IDs y tests de casos con tildes.
+
+3. **Riesgo: lógica de desempate inconsistente respecto a Flask**
+   - Mitigación: test matrix de escenarios (rama única, empate ramas, empate carreras, contexto inválido).
+
+4. **Riesgo: acoplar dominio a framework durante migración rápida**
+   - Mitigación: regla de arquitectura: dominio puro + lint/import boundaries.
+
+5. **Riesgo: regresión UX en navegación del flujo**
+   - Mitigación: smoke checklist de navegación y rendering de resultados por tipo de estado.
+
+---
+
+## 9) Estrategia de pruebas mínimas
+
+### Unit tests (obligatorio)
+
+- Foco en `evaluarRamas` y `evaluarCarreras`.
+- Casos mínimos:
+  - rama única ganadora,
+  - empate de ramas,
+  - carrera única ganadora,
+  - empate de carreras,
+  - payload/contexto inválido.
+
+### Smoke e2e/manual (mínimo viable)
+
+Checklist:
+
+1. Iniciar quiz desde Home.
+2. Completar preguntas generales y verificar transición correcta.
+3. Forzar escenario de empate de ramas y resolver desempate.
+4. Verificar render final para `resultado_final` y `empate_carrera`.
+5. Validar mensaje de error ante payload faltante (simulado).
+
+Herramienta sugerida para evolución: Playwright (no bloqueante para v1).
+
+---
+
+## 10) Plan de despliegue en Vercel y rollback básico
+
+### Despliegue
+
+1. Conectar repositorio a Vercel (framework preset Next.js).
+2. Configurar ramas:
+   - `main` → Production
+   - feature branches → Preview
+3. Variables de entorno:
+   - v1 idealmente sin variables críticas para core.
+4. Validaciones previas a promote:
+   - unit tests verdes,
+   - smoke manual completado,
+   - revisión de contratos API.
+
+### Rollback básico
+
+Estrategia recomendada (sin complejidad extra):
+
+- Si falla release en producción, usar **Promote Previous Deployment** en Vercel para volver al último build estable.
+- Mantener tag/versionado por release (`vX.Y.Z`) para trazabilidad.
+- Si hubo cambio de contrato, preservar compatibilidad temporal en rutas o response fields hasta estabilizar frontend.
+
+---
+
+## Decisiones técnicas explícitas para v1
+
+- **Sin base de datos**: catálogo en memoria versionado en código.
+- **Sin autenticación**: endpoints públicos internos del producto.
+- **TypeScript strict** como estándar de tipado.
+- **Validación runtime con Zod** para requests y respuestas críticas.
+- **Paridad funcional primero**, optimizaciones/limpieza de UX en iteraciones posteriores.


### PR DESCRIPTION
## Summary
- add essential project documentation set to guide the direct rewrite to Next.js serverless on Vercel (PRD, ADR-001, technical migration spec, DoD/release checklist)
- add a canonical API contract document with kebab-case routes and legacy compatibility notes
- expand README with project status, architecture direction, docs index, current flow, and local setup instructions

## Why
This creates a minimal but complete documentation baseline so implementation can start quickly with aligned product scope, architectural decisions, API contracts, and release criteria.

## Scope
- docs-only + README updates
- no runtime behavior changes
- existing unstaged local changes in `server/app.py` were intentionally excluded from this PR