### PR TITLE
feat(quality): harden quiz recovery and API smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,19 @@ Abrir `http://localhost:3000`.
 
 ```bash
 npm test
+npm run test:smoke
 npx tsc --noEmit
+```
+
+## Smoke tests ejecutables
+
+- Archivo: `tests/smoke/api.smoke.test.ts`
+- Manual complementario: `tests/smoke/flujo-migracion.smoke.md`
+
+Ejecutar:
+
+```bash
+npm run test:smoke
 ```
 
 ## Documentación

--- a/app/api/evaluar-carrera/route.ts
+++ b/app/api/evaluar-carrera/route.ts
@@ -23,6 +23,10 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: zodErrorToMessage(error) }, { status: 400 });
     }
 
-    return NextResponse.json({ error: "No se recibieron datos" }, { status: 400 });
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: "No se recibieron datos" }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: "Error interno inesperado" }, { status: 500 });
   }
 }

--- a/app/api/evaluar-ramas/route.ts
+++ b/app/api/evaluar-ramas/route.ts
@@ -15,6 +15,10 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: zodErrorToMessage(error) }, { status: 400 });
     }
 
-    return NextResponse.json({ error: "No se recibieron datos" }, { status: 400 });
+    if (error instanceof SyntaxError) {
+      return NextResponse.json({ error: "No se recibieron datos" }, { status: 400 });
+    }
+
+    return NextResponse.json({ error: "Error interno inesperado" }, { status: 500 });
   }
 }

--- a/app/api/preguntas-generales/route.ts
+++ b/app/api/preguntas-generales/route.ts
@@ -2,5 +2,9 @@ import { NextResponse } from "next/server";
 import { getPreguntasGenerales } from "../../../src/application/use-cases/getPreguntasGenerales";
 
 export async function GET() {
-  return NextResponse.json(getPreguntasGenerales());
+  try {
+    return NextResponse.json(getPreguntasGenerales());
+  } catch {
+    return NextResponse.json({ error: "Error interno inesperado" }, { status: 500 });
+  }
 }

--- a/app/questions/page.tsx
+++ b/app/questions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 type Respuesta = "sí" | "no";
@@ -73,25 +73,40 @@ export default function QuestionsPage() {
   const [ramaSeleccionada, setRamaSeleccionada] = useState<string | null>(null);
   const [ramasEmpatadas, setRamasEmpatadas] = useState<string[]>([]);
 
-  useEffect(() => {
-    async function cargarPreguntas() {
-      try {
-        const res = await fetch("/api/preguntas-generales");
-        const data = (await res.json()) as Record<string, string[]>;
-        setPreguntasGenerales(flattenGenerales(data));
-      } catch {
-        setError("No se pudieron cargar las preguntas.");
-      } finally {
-        setLoading(false);
-      }
+  async function readJsonSafe<T>(res: Response): Promise<T | null> {
+    try {
+      return (await res.json()) as T;
+    } catch {
+      return null;
     }
+  }
+
+  async function cargarPreguntas() {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/preguntas-generales");
+      const data = await readJsonSafe<Record<string, string[]>>(res);
+
+      if (!res.ok || !data) {
+        setError("No se pudieron cargar las preguntas. Probá reintentar.");
+        return;
+      }
+
+      setPreguntasGenerales(flattenGenerales(data));
+    } catch {
+      setError("No se pudieron cargar las preguntas. Probá reintentar.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
     void cargarPreguntas();
   }, []);
 
-  const listaActual = useMemo(() => {
-    if (fase === "general") return preguntasGenerales;
-    return preguntasCarrera;
-  }, [fase, preguntasGenerales, preguntasCarrera]);
+  const listaActual = fase === "general" ? preguntasGenerales : preguntasCarrera;
 
   const actual = listaActual[indice];
 
@@ -108,10 +123,15 @@ export default function QuestionsPage() {
       body: JSON.stringify(payload),
     });
 
-    const data = (await res.json()) as ResultadoRamas | { error: string };
+    const data = await readJsonSafe<ResultadoRamas | { error: string }>(res);
+
+    if (!data) {
+      setError("Respuesta inválida evaluando ramas. Probá reintentar.");
+      return;
+    }
 
     if (!res.ok || "error" in data) {
-      setError("error" in data ? data.error : "Error evaluando ramas.");
+      setError("error" in data ? data.error : "Error evaluando ramas. Probá reintentar.");
       return;
     }
 
@@ -150,10 +170,15 @@ export default function QuestionsPage() {
       body: JSON.stringify(payload),
     });
 
-    const data = (await res.json()) as ResultadoFinal | { error: string };
+    const data = await readJsonSafe<ResultadoFinal | { error: string }>(res);
+
+    if (!data) {
+      setError("Respuesta inválida evaluando carrera. Probá reintentar.");
+      return;
+    }
 
     if (!res.ok || "error" in data) {
-      setError("error" in data ? data.error : "Error evaluando carrera.");
+      setError("error" in data ? data.error : "Error evaluando carrera. Probá reintentar.");
       return;
     }
 
@@ -189,6 +214,27 @@ export default function QuestionsPage() {
     }
   }
 
+  async function reintentar() {
+    if (fase === "general" && preguntasGenerales.length === 0) {
+      await cargarPreguntas();
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      if (fase === "general") {
+        await evaluarRamas();
+      } else {
+        await evaluarCarrera();
+      }
+    } catch {
+      setError("No se pudo reintentar. Volvé al inicio.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
   if (loading) {
     return (
       <main>
@@ -201,6 +247,10 @@ export default function QuestionsPage() {
     return (
       <main>
         <p className="error">{error}</p>
+        <div className="row">
+          <button onClick={() => void reintentar()}>Reintentar</button>
+          <button className="secondary" onClick={() => router.push("/")}>Volver al inicio</button>
+        </div>
       </main>
     );
   }

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -12,21 +12,50 @@ type Resultado = {
 
 export default function ResultsPage() {
   const [resultado, setResultado] = useState<Resultado | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function isResultado(value: unknown): value is Resultado {
+    if (!value || typeof value !== "object") return false;
+    const candidate = value as Partial<Resultado>;
+    const statusValido =
+      candidate.status === "resultado_final" ||
+      candidate.status === "empate_carrera" ||
+      candidate.status === "no_carreras_evaluadas";
+    return statusValido && typeof candidate.message === "string";
+  }
 
   useEffect(() => {
-    const raw = sessionStorage.getItem("voca-ia-resultado");
-    if (!raw) return;
-    setResultado(JSON.parse(raw) as Resultado);
+    try {
+      const raw = sessionStorage.getItem("voca-ia-resultado");
+      if (!raw) return;
+
+      const parsed = JSON.parse(raw) as unknown;
+      if (!isResultado(parsed)) {
+        sessionStorage.removeItem("voca-ia-resultado");
+        setError("Resultado inválido. Hacé el quiz de nuevo.");
+        return;
+      }
+
+      setResultado(parsed);
+    } catch {
+      sessionStorage.removeItem("voca-ia-resultado");
+      setError("Resultado corrupto. Hacé el quiz de nuevo.");
+    }
   }, []);
 
   if (!resultado) {
     return (
       <main>
         <h1>Results</h1>
-        <p className="error">No hay resultado. Hacé el quiz primero.</p>
-        <Link href="/" className="btn">
-          Volver al inicio
-        </Link>
+        <p className="error">{error ?? "No hay resultado. Hacé el quiz primero."}</p>
+        <div className="row">
+          <Link href="/questions" className="btn">
+            Reintentar quiz
+          </Link>
+          <Link href="/" className="btn secondary">
+            Volver al inicio
+          </Link>
+        </div>
       </main>
     );
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:smoke": "vitest run tests/smoke/api.smoke.test.ts"
   },
   "dependencies": {
     "next": "^15.0.0",

--- a/tests/smoke/api.smoke.test.ts
+++ b/tests/smoke/api.smoke.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { GET as getPreguntasGenerales } from "../../app/api/preguntas-generales/route";
+import { POST as postEvaluarRamas } from "../../app/api/evaluar-ramas/route";
+import { POST as postEvaluarCarrera } from "../../app/api/evaluar-carrera/route";
+
+function createPostRequest(url: string, body: unknown) {
+  return new Request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("Smoke API", () => {
+  it("GET /api/preguntas-generales responde 200 y shape base", async () => {
+    const response = await getPreguntasGenerales();
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body).toBeTypeOf("object");
+
+    const ramas = Object.keys(body);
+    expect(ramas.length).toBeGreaterThan(0);
+    const primeraRama = body[ramas[0]];
+    expect(Array.isArray(primeraRama)).toBe(true);
+  });
+
+  it("POST /api/evaluar-ramas válido", async () => {
+    const payload = {
+      "Ingeniería y Ciencias Físico Matemáticas_0": "sí",
+    };
+
+    const response = await postEvaluarRamas(createPostRequest("http://localhost/api/evaluar-ramas", payload));
+    const body = (await response.json()) as { status?: string; error?: string };
+
+    expect(response.status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.status).toBeTruthy();
+  });
+
+  it("POST /api/evaluar-ramas inválido", async () => {
+    const response = await postEvaluarRamas(createPostRequest("http://localhost/api/evaluar-ramas", {}));
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("POST /api/evaluar-carrera válido", async () => {
+    const payload = {
+      rama: "Ingeniería y Ciencias Físico Matemáticas",
+      respuestas: {
+        "Ingeniería en Sistemas Computacionales_0": "sí",
+      },
+    };
+
+    const response = await postEvaluarCarrera(createPostRequest("http://localhost/api/evaluar-carrera", payload));
+    const body = (await response.json()) as { status?: string; error?: string };
+
+    expect(response.status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.status).toBeTruthy();
+  });
+
+  it("POST /api/evaluar-carrera sin contexto", async () => {
+    const payload = {
+      respuestas: {
+        "Ingeniería en Sistemas Computacionales_0": "sí",
+      },
+    };
+
+    const response = await postEvaluarCarrera(createPostRequest("http://localhost/api/evaluar-carrera", payload));
+    const body = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("No se proporcionó contexto de rama o desempate válido");
+  });
+});


### PR DESCRIPTION
Closes #5

## Type
- [x] New feature

## Summary
- improve quiz/result error recovery and safe JSON handling
- make API unexpected errors return consistent 500 payloads
- add executable API smoke tests and `test:smoke` script

## Test Plan
- [x] `npm test`
- [x] `npm run test:smoke`
- [x] `npx tsc --noEmit`
- [x] No build executed