### PR TITLE
chore(deploy): prepare Vercel rollout and rollback docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Plataforma de orientación vocacional.
 
 Repositorio consolidado en **Next.js 15 + App Router + Route Handlers** (TypeScript).
 
+### Alcance v1
+
+- Sin base de datos.
+- Sin autenticación.
+- Deploy objetivo: **Vercel**.
+
 ## Stack
 
 - Next.js 15
@@ -44,6 +50,49 @@ npm run test:smoke
 npx tsc --noEmit
 ```
 
+## Deploy en Vercel paso a paso
+
+### Prerequisitos
+
+1. Node.js instalado para validación local.
+2. Cuenta y proyecto en Vercel conectados al repo.
+3. Rama lista con validaciones locales en verde.
+4. Confirmar que v1 no requiere DB ni auth.
+
+### Comandos a correr antes del deploy
+
+```bash
+npm test
+npm run test:smoke
+npx tsc --noEmit
+```
+
+### Pasos en Vercel
+
+1. Importar/conectar el repo en Vercel.
+2. Framework detectado: **Next.js**.
+3. Root directory: repo raíz.
+4. No agregar variables de entorno para v1 salvo que cambie alcance.
+5. Ejecutar deploy de preview sobre la rama.
+6. Validar preview con `tests/smoke/flujo-migracion.smoke.md`.
+7. Promover a producción cuando el smoke manual dé ok.
+
+### Qué validar post deploy
+
+- `/` carga y navega a `/questions`.
+- `/questions` obtiene preguntas y permite completar flujo.
+- `/results` resuelve fallback si entrás sin estado.
+- Casos de empate y errores visibles siguen funcionando.
+- APIs `/api/preguntas-generales`, `/api/evaluar-ramas` y `/api/evaluar-carrera` responden.
+
+### Rollback básico
+
+1. Ir a Vercel → Deployments.
+2. Identificar último deploy sano.
+3. Promover ese deployment o redeploy del commit estable.
+4. Repetir smoke manual básico.
+5. Documentar incidente antes de reintentar.
+
 ## Smoke tests ejecutables
 
 - Archivo: `tests/smoke/api.smoke.test.ts`
@@ -62,3 +111,4 @@ npm run test:smoke
 - [`docs/spec-migracion-next.md`](docs/spec-migracion-next.md)
 - [`docs/api-contract.md`](docs/api-contract.md)
 - [`docs/dod-release-checklist.md`](docs/dod-release-checklist.md)
+- [`docs/operacion-produccion.md`](docs/operacion-produccion.md)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,14 @@
 import "./globals.css";
+import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
-export const metadata = {
-  title: "Voca-IA",
-  description: "Orientación vocacional",
+export const metadata: Metadata = {
+  title: {
+    default: "Voca-IA",
+    template: "%s | Voca-IA",
+  },
+  description: "Orientación vocacional simple para explorar ramas y carreras.",
+  applicationName: "Voca-IA",
 };
 
 type Props = { children: ReactNode };

--- a/docs/operacion-produccion.md
+++ b/docs/operacion-produccion.md
@@ -1,0 +1,56 @@
+# Operación producción v1 — Voca-IA
+
+Documento corto para deploy y rollback en **Vercel**.
+
+## 1. Prerequisitos
+
+- Repo conectado a Vercel.
+- Rama lista para promotion.
+- Validaciones locales en verde:
+
+```bash
+npm test
+npm run test:smoke
+npx tsc --noEmit
+```
+
+- Confirmado: **v1 no usa DB ni auth**.
+
+## 2. Deploy en Vercel
+
+1. Abrir proyecto en Vercel.
+2. Verificar branch y commit correctos.
+3. Confirmar detección automática de **Next.js**.
+4. Confirmar que no haya env vars nuevas requeridas para v1.
+5. Lanzar deploy preview.
+6. Ejecutar checklist manual de `tests/smoke/flujo-migracion.smoke.md` sobre la preview.
+7. Si todo da bien, promover a producción.
+
+## 3. Qué validar post deploy
+
+- Home `/` renderiza bien y CTA navega a `/questions`.
+- `/questions` carga preguntas generales.
+- Flujo normal termina en `/results` con resultado final.
+- Acceso directo a `/results` muestra fallback usable.
+- Caso de empate sigue visible y entendible.
+- Casos de error siguen mostrando mensaje claro.
+- Endpoints críticos responden:
+  - `GET /api/preguntas-generales`
+  - `POST /api/evaluar-ramas`
+  - `POST /api/evaluar-carrera`
+
+## 4. Rollback básico
+
+Aplicar rollback si el flujo no termina, hay errores críticos repetidos o la UX queda rota.
+
+1. Ir a **Vercel → Deployments**.
+2. Elegir último deployment estable.
+3. Promover ese deployment o redeployar el commit estable.
+4. Repetir smoke manual mínimo en producción.
+5. Registrar incidente y causa probable antes de redeploy nuevo.
+
+## 5. Notas operativas
+
+- No usar `npm run build` como validación manual de esta fase.
+- No agregar `vercel.json` salvo necesidad real futura.
+- Headers básicos de seguridad quedan centralizados en `next.config.ts`.

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,31 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/tests/smoke/flujo-migracion.smoke.md
+++ b/tests/smoke/flujo-migracion.smoke.md
@@ -1,10 +1,55 @@
-# Smoke checklist migración Next (manual)
+# Smoke checklist migración Next (manual post-deploy)
 
-1. Entrar a `/` y click en **Empezar quiz**.
-2. Completar preguntas generales.
-3. Verificar transición a rama elegida o desempate de ramas.
-4. Completar preguntas de carrera.
-5. Verificar `/results` para:
-   - `resultado_final`
-   - `empate_carrera`
-   - `no_carreras_evaluadas` (si aplica por contexto)
+Usar este checklist sobre **Preview** y luego sobre **Producción**.
+
+## 1. Homepage
+
+- [ ] Entrar a `/`.
+- [ ] Verificar que la página renderiza sin error visual.
+- [ ] Verificar presencia del CTA principal.
+- [ ] Hacer click en **Empezar quiz**.
+- [ ] Confirmar navegación correcta a `/questions`.
+
+## 2. Questions — ruta feliz
+
+- [ ] Confirmar que `/questions` carga preguntas generales.
+- [ ] Responder todas las preguntas generales con valores válidos.
+- [ ] Confirmar que el flujo avanza sin pantallas en blanco.
+- [ ] Si sale `rama_elegida`, completar preguntas de carrera.
+- [ ] Confirmar llegada a `/results`.
+- [ ] Verificar que existe recomendación final visible (`resultado_final`) o fallback coherente si no hubo carreras evaluadas.
+
+## 3. Results fallback
+
+- [ ] Abrir `/results` directo en una pestaña nueva o refrescar sin estado válido.
+- [ ] Confirmar que aparece fallback entendible.
+- [ ] Confirmar que existe CTA para reiniciar o volver al flujo.
+- [ ] Confirmar que no rompe la app ni deja pantalla vacía.
+
+## 4. Empate de ramas / empate de carrera
+
+- [ ] Forzar o reproducir un caso de `empate_ramas_desempate`.
+- [ ] Confirmar que el mensaje de empate se entiende.
+- [ ] Confirmar que aparecen preguntas para desempate.
+- [ ] Completar desempate y seguir flujo.
+- [ ] Validar un caso final con `empate_carrera`.
+- [ ] Confirmar que `/results` muestra el empate de forma clara.
+
+## 5. Errores visibles
+
+- [ ] Verificar que si falla carga de preguntas generales hay mensaje entendible.
+- [ ] Verificar que si falla evaluación de ramas hay mensaje entendible.
+- [ ] Verificar que si falla evaluación de carrera hay mensaje entendible.
+- [ ] Confirmar que ningún error deja navegación bloqueada sin salida.
+
+## 6. APIs críticas
+
+- [ ] `GET /api/preguntas-generales` responde.
+- [ ] `POST /api/evaluar-ramas` responde.
+- [ ] `POST /api/evaluar-carrera` responde.
+
+## 7. Cierre
+
+- [ ] Smoke manual completo en Preview.
+- [ ] Smoke manual completo en Producción.
+- [ ] Si algo falla, rollback al deployment estable anterior.


### PR DESCRIPTION
Closes #6

## Type
- [x] Maintenance/tooling

## Summary
- add basic secure headers and app metadata for Vercel deployment readiness
- document production operation, deploy validation, and rollback path
- expand manual post-deploy smoke checklist

## Test Plan
- [x] `npm test`
- [x] `npm run test:smoke`
- [x] `npx tsc --noEmit`
- [x] No build executed