### PR TITLE
docs(planning): add release checklist and migration master plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ npm run test:smoke
 
 ## Documentación
 
+- [`docs/migration-master-plan.md`](docs/migration-master-plan.md)
+- [`docs/planning-index.md`](docs/planning-index.md)
 - [`docs/prd.md`](docs/prd.md)
 - [`docs/adr/001-nextjs-serverless-v1.md`](docs/adr/001-nextjs-serverless-v1.md)
 - [`docs/spec-migracion-next.md`](docs/spec-migracion-next.md)

--- a/README.md
+++ b/README.md
@@ -111,4 +111,6 @@ npm run test:smoke
 - [`docs/spec-migracion-next.md`](docs/spec-migracion-next.md)
 - [`docs/api-contract.md`](docs/api-contract.md)
 - [`docs/dod-release-checklist.md`](docs/dod-release-checklist.md)
+- [`docs/release-checklist.md`](docs/release-checklist.md)
 - [`docs/operacion-produccion.md`](docs/operacion-produccion.md)
+- [`docs/pr-comment-phase5.md`](docs/pr-comment-phase5.md)

--- a/docs/migration-master-plan.md
+++ b/docs/migration-master-plan.md
@@ -62,10 +62,10 @@ El repositorio ya es **Next-only**. `client/` y `server/` legacy fueron removido
 | Fase 1 — Next base + dominio | DONE | Next.js 15, App Router, Route Handlers, dominio puro, tests unitarios y AGENTS por capas completados. |
 | Fase 2 — Remoción legacy | DONE | `client/` y `server/` removidos. Repo consolidado como Next-only. |
 | Fase 3 — Hardening UX/API | DONE | Manejo de errores UX/API reforzado y smoke tests API ejecutables agregados. |
-| Fase 4 — Preparación Vercel | BLOCKED | Configuración, headers, metadata y docs de producción/rollback listas localmente. Bloqueado solo por push SSH pendiente. |
-| Fase 5 — Release humano final | BLOCKED | Checklist final y comentario PR listos localmente. Falta push, preview, validación prod y merge. |
+| Fase 4 — Preparación Vercel | DONE | Configuración, headers, metadata y docs de producción/rollback listas. |
+| Fase 5 — Release humano final | DONE | Checklist final, comentario PR, plan maestro e índice listos. |
 
-No hay fases funcionales pendientes dentro del repo local. Lo pendiente es publicación/validación remota.
+No hay fases funcionales pendientes. Lo pendiente operativo es validar Preview/Prod en Vercel antes del cierre final.
 
 ## 5. Commits relevantes conocidos
 
@@ -78,7 +78,7 @@ No hay fases funcionales pendientes dentro del repo local. Lo pendiente es publi
 
 ## 6. Validaciones requeridas
 
-Ejecutar antes de push, PR, preview y cierre:
+Ejecutar antes de PR, preview, producción y cierre:
 
 ```bash
 npm test
@@ -94,43 +94,32 @@ npm run build
 
 ## 7. Estado actual exacto
 
-- Rama actual: `feat/next-rewrite-phase-1`.
-- Tracking: `origin/feat/next-rewrite-phase-1`.
-- Estado git conocido: rama local **ahead 2**.
-- Commits locales pendientes de push:
-  - `6cc1361`
-  - `32bc072`
-- Bloqueante actual: **push por SSH pendiente**.
-- No hacer push hasta que el acceso SSH vuelva.
+- Rama de trabajo original: `feat/next-rewrite-phase-1`.
+- Estrategia final: PRs secuenciales por fase para trazabilidad.
 - No hay que tocar lógica de app para cerrar planeación.
+- Validación humana pendiente: Preview y Producción en Vercel.
 
-## 8. Próximos pasos cuando vuelva push
+## 8. Próximos pasos operativos
 
-1. Confirmar rama:
-   ```bash
-   git status --short --branch
-   ```
-2. Confirmar que sigue `ahead 2` y sin cambios inesperados.
-3. Ejecutar validaciones locales:
+1. Ejecutar validaciones locales:
    ```bash
    npm test
    npm run test:smoke
    npx tsc --noEmit
    ```
-4. Hacer push de `feat/next-rewrite-phase-1`.
-5. Abrir o actualizar PR.
-6. Pegar comentario usando `docs/pr-comment-phase5.md`.
-7. Esperar preview de Vercel.
-8. Ejecutar smoke manual de `tests/smoke/flujo-migracion.smoke.md` en preview.
-9. Si preview da OK, promover a producción.
-10. Repetir smoke manual en producción.
-11. Mergear solo con preview y producción validadas.
+2. Abrir/actualizar PR de la fase vigente.
+3. Pegar comentario usando `docs/pr-comment-phase5.md` en la PR final.
+4. Esperar preview de Vercel.
+5. Ejecutar smoke manual de `tests/smoke/flujo-migracion.smoke.md` en preview.
+6. Si preview da OK, promover a producción.
+7. Repetir smoke manual en producción.
+8. Mergear solo con preview y producción validadas.
 
 ## 9. Riesgos y mitigaciones
 
 | Riesgo | Mitigación |
 |---|---|
-| Push SSH sigue bloqueado | No reescribir historia. Resolver acceso y pushear la rama actual. |
+| Drift entre PRs secuenciales | Mergear fases en orden y revalidar después de cada merge. |
 | Drift entre docs | Usar este plan como estado global; usar `docs/planning-index.md` para elegir documento. |
 | Regresión de contrato API | Ejecutar `npm run test:smoke` y revisar `docs/api-contract.md`. |
 | Regresión de flujo UX | Ejecutar smoke manual en preview y prod. |
@@ -141,8 +130,7 @@ npm run build
 
 La migración queda cerrada al 100% cuando:
 
-- La rama `feat/next-rewrite-phase-1` está pusheada.
-- La PR existe o está actualizada con contexto claro.
+- Las PRs de fase fueron creadas con contexto claro.
 - `npm test` está verde.
 - `npm run test:smoke` está verde.
 - `npx tsc --noEmit` está verde.

--- a/docs/migration-master-plan.md
+++ b/docs/migration-master-plan.md
@@ -1,0 +1,153 @@
+# Plan maestro de migración — Voca-IA
+
+Fuente de verdad final para continuar la migración y release de Voca-IA.
+
+## 1. Objetivo del proyecto
+
+Consolidar Voca-IA en una única aplicación **Next.js 15 + App Router + Route Handlers**, desplegable en **Vercel**, manteniendo paridad funcional del flujo vocacional v1:
+
+1. Home `/`.
+2. Quiz `/questions`.
+3. Evaluación de ramas.
+4. Desempate de ramas si aplica.
+5. Evaluación de carreras.
+6. Resultado `/results`.
+
+Alcance v1:
+
+- Sin base de datos.
+- Sin autenticación.
+- Catálogo de preguntas versionado en código.
+- API interna serverless en Next.
+- Validación local sin ejecutar `npm run build`.
+
+## 2. Arquitectura final
+
+Arquitectura activa:
+
+- `app/`: UI con App Router.
+- `app/api/**/route.ts`: Route Handlers serverless.
+- `src/domain/**`: reglas puras, sin Next, React, `window` ni transporte HTTP.
+- `src/application/**`: casos de uso/orquestación.
+- `src/infrastructure/**`: catálogos en memoria, schemas y adaptadores HTTP.
+- `tests/unit/**`: validación de dominio.
+- `tests/smoke/**`: smoke tests API y checklist manual.
+
+Endpoints canónicos:
+
+- `GET /api/preguntas-generales`
+- `POST /api/evaluar-ramas`
+- `POST /api/evaluar-carrera`
+
+El repositorio ya es **Next-only**. `client/` y `server/` legacy fueron removidos.
+
+## 3. Decisiones aceptadas
+
+- Usar **Next.js 15 + App Router** como plataforma única.
+- Usar **Route Handlers** para API serverless.
+- Desplegar en **Vercel**.
+- Mantener v1 **sin DB** y **sin auth**.
+- Mantener dominio puro separado de framework e infraestructura.
+- Usar rutas API canónicas en **kebab-case**.
+- Validar runtime con **Zod**.
+- No ejecutar `npm run build` como validación manual de esta fase.
+- Fuente de verdad de contrato API: `docs/api-contract.md`.
+- Fuente de verdad operativa de release: `docs/release-checklist.md`.
+- Fuente de verdad de estado global: este documento.
+
+## 4. Fases y estado
+
+| Fase | Estado | Resultado |
+|---|---|---|
+| Fase 1 — Next base + dominio | DONE | Next.js 15, App Router, Route Handlers, dominio puro, tests unitarios y AGENTS por capas completados. |
+| Fase 2 — Remoción legacy | DONE | `client/` y `server/` removidos. Repo consolidado como Next-only. |
+| Fase 3 — Hardening UX/API | DONE | Manejo de errores UX/API reforzado y smoke tests API ejecutables agregados. |
+| Fase 4 — Preparación Vercel | BLOCKED | Configuración, headers, metadata y docs de producción/rollback listas localmente. Bloqueado solo por push SSH pendiente. |
+| Fase 5 — Release humano final | BLOCKED | Checklist final y comentario PR listos localmente. Falta push, preview, validación prod y merge. |
+
+No hay fases funcionales pendientes dentro del repo local. Lo pendiente es publicación/validación remota.
+
+## 5. Commits relevantes conocidos
+
+- `998e6dc` — `feat(next): migrate quiz flow to app router and serverless api`
+- `b44ff57` — `chore(repo): remove legacy vite and flask code after phase 2`
+- `95a3908` — `docs: update project status after legacy removal`
+- `c90e9d5` — `feat(quality): harden error recovery and add api smoke tests`
+- `6cc1361` — `chore(deploy): prepare vercel rollout and rollback docs`
+- `32bc072` — `docs(release): add final human rollout checklist`
+
+## 6. Validaciones requeridas
+
+Ejecutar antes de push, PR, preview y cierre:
+
+```bash
+npm test
+npm run test:smoke
+npx tsc --noEmit
+```
+
+No ejecutar:
+
+```bash
+npm run build
+```
+
+## 7. Estado actual exacto
+
+- Rama actual: `feat/next-rewrite-phase-1`.
+- Tracking: `origin/feat/next-rewrite-phase-1`.
+- Estado git conocido: rama local **ahead 2**.
+- Commits locales pendientes de push:
+  - `6cc1361`
+  - `32bc072`
+- Bloqueante actual: **push por SSH pendiente**.
+- No hacer push hasta que el acceso SSH vuelva.
+- No hay que tocar lógica de app para cerrar planeación.
+
+## 8. Próximos pasos cuando vuelva push
+
+1. Confirmar rama:
+   ```bash
+   git status --short --branch
+   ```
+2. Confirmar que sigue `ahead 2` y sin cambios inesperados.
+3. Ejecutar validaciones locales:
+   ```bash
+   npm test
+   npm run test:smoke
+   npx tsc --noEmit
+   ```
+4. Hacer push de `feat/next-rewrite-phase-1`.
+5. Abrir o actualizar PR.
+6. Pegar comentario usando `docs/pr-comment-phase5.md`.
+7. Esperar preview de Vercel.
+8. Ejecutar smoke manual de `tests/smoke/flujo-migracion.smoke.md` en preview.
+9. Si preview da OK, promover a producción.
+10. Repetir smoke manual en producción.
+11. Mergear solo con preview y producción validadas.
+
+## 9. Riesgos y mitigaciones
+
+| Riesgo | Mitigación |
+|---|---|
+| Push SSH sigue bloqueado | No reescribir historia. Resolver acceso y pushear la rama actual. |
+| Drift entre docs | Usar este plan como estado global; usar `docs/planning-index.md` para elegir documento. |
+| Regresión de contrato API | Ejecutar `npm run test:smoke` y revisar `docs/api-contract.md`. |
+| Regresión de flujo UX | Ejecutar smoke manual en preview y prod. |
+| Deploy Vercel falla | No promover a prod. Revisar logs, corregir rama y regenerar preview. |
+| Falla en producción | Aplicar rollback de `docs/operacion-produccion.md`. |
+
+## 10. Criterios de cierre total
+
+La migración queda cerrada al 100% cuando:
+
+- La rama `feat/next-rewrite-phase-1` está pusheada.
+- La PR existe o está actualizada con contexto claro.
+- `npm test` está verde.
+- `npm run test:smoke` está verde.
+- `npx tsc --noEmit` está verde.
+- Preview de Vercel está generada y validada manualmente.
+- Producción está promovida y validada manualmente.
+- No hay rollback activo.
+- La PR fue aprobada y mergeada.
+- README y docs apuntan a este plan maestro y al índice.

--- a/docs/operacion-produccion.md
+++ b/docs/operacion-produccion.md
@@ -2,6 +2,8 @@
 
 Documento corto para deploy y rollback en **Vercel**.
 
+Checklist operativo final: `docs/release-checklist.md`.
+
 ## 1. Prerequisitos
 
 - Repo conectado a Vercel.
@@ -24,7 +26,8 @@ npx tsc --noEmit
 4. Confirmar que no haya env vars nuevas requeridas para v1.
 5. Lanzar deploy preview.
 6. Ejecutar checklist manual de `tests/smoke/flujo-migracion.smoke.md` sobre la preview.
-7. Si todo da bien, promover a producción.
+7. Seguir go/no-go de `docs/release-checklist.md`.
+8. Si todo da bien, promover a producción.
 
 ## 3. Qué validar post deploy
 

--- a/docs/planning-index.md
+++ b/docs/planning-index.md
@@ -1,0 +1,19 @@
+# Índice de planeación — Voca-IA
+
+Usá este mapa para saber qué documento abrir.
+
+| Necesidad | Documento |
+|---|---|
+| Estado global de migración y próximos pasos | `docs/migration-master-plan.md` |
+| Contrato canónico de API | `docs/api-contract.md` |
+| Decisión de arquitectura Next/Vercel | `docs/adr/001-nextjs-serverless-v1.md` |
+| Especificación técnica histórica de migración | `docs/spec-migracion-next.md` |
+| Checklist final de release humano | `docs/release-checklist.md` |
+| Operación, deploy y rollback en Vercel | `docs/operacion-produccion.md` |
+| Comentario corto para PR | `docs/pr-comment-phase5.md` |
+| Definition of Done general | `docs/dod-release-checklist.md` |
+| Contexto de producto | `docs/prd.md` |
+| Smoke manual de flujo | `tests/smoke/flujo-migracion.smoke.md` |
+| Smoke API ejecutable | `tests/smoke/api.smoke.test.ts` |
+
+Regla: si dos documentos parecen repetir información, tomar `docs/migration-master-plan.md` como estado global vigente.

--- a/docs/pr-comment-phase5.md
+++ b/docs/pr-comment-phase5.md
@@ -2,9 +2,9 @@
 
 ## Estado
 
-- Fase 5 lista localmente.
-- Queda listo release humano.
-- Bloqueante actual: push pendiente por SSH.
+- Fase 5 lista.
+- Planeación final centralizada.
+- Release humano listo para Preview -> Prod -> Merge.
 
 ## Validación local
 
@@ -12,7 +12,7 @@
 - `npm run test:smoke` ✅
 - `npx tsc --noEmit` ✅
 
-## Qué validar al destrabarse el push
+## Qué validar ahora
 
 1. Generar preview.
 2. Ejecutar smoke manual en preview.

--- a/docs/pr-comment-phase5.md
+++ b/docs/pr-comment-phase5.md
@@ -1,0 +1,26 @@
+# PR comment corto — Fase 5
+
+## Estado
+
+- Fase 5 lista localmente.
+- Queda listo release humano.
+- Bloqueante actual: push pendiente por SSH.
+
+## Validación local
+
+- `npm test` ✅
+- `npm run test:smoke` ✅
+- `npx tsc --noEmit` ✅
+
+## Qué validar al destrabarse el push
+
+1. Generar preview.
+2. Ejecutar smoke manual en preview.
+3. Si da ok, promover a prod.
+4. Repetir smoke en prod.
+5. Si prod da ok, merge.
+
+## Docs operativas
+
+- `docs/release-checklist.md`
+- `tests/smoke/flujo-migracion.smoke.md`

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -2,42 +2,41 @@
 
 Estado global vigente: `docs/migration-master-plan.md`.
 
-Estado de esta fase: **listo para release humano**.
-
-Bloqueante actual: **falta push de la rama local por bloqueo SSH**.
+Estado de esta fase: **listo para validación humana en Vercel**.
 
 ## 1. Qué está listo hoy
 
-- Fases 1-5 implementadas localmente.
+- Fases 1-5 implementadas y separadas en PRs por trazabilidad.
 - Validación local requerida ejecutable:
   - `npm test`
   - `npm run test:smoke`
   - `npx tsc --noEmit`
-- Documentación operativa lista para hacer release apenas se destrabe el push.
+- Documentación operativa lista para preview, producción y merge final.
 
-## 2. Push pendiente
+## 2. PRs y trazabilidad
 
-Hacer esto apenas vuelva el acceso SSH:
+Cada fase debe tener PR propia y issue aprobado.
 
-1. Verificar rama actual correcta.
-2. Verificar cambios esperados con `git status`.
-3. Pushear la rama local pendiente al remoto.
-4. Confirmar que el commit local de Fase 4 y los cambios de Fase 5 quedaron en remoto.
-5. Abrir o actualizar la PR.
-6. Publicar comentario de estado usando `docs/pr-comment-phase5.md`.
+1. Fase 1: core Next.
+2. Fase 2: limpieza legacy.
+3. Fase 3: hardening + smoke tests.
+4. Fase 4: preparación Vercel.
+5. Fase 5: release/planning final.
+
+Usar `docs/pr-comment-phase5.md` como resumen para la última PR.
 
 ## 3. Release exacto: preview -> prod -> merge
 
-### A. Antes del push
+### A. Antes de validar preview
 
 - [ ] `npm test` verde.
 - [ ] `npm run test:smoke` verde.
 - [ ] `npx tsc --noEmit` verde.
-- [ ] Sin cambios locales inesperados.
+- [ ] PRs de fases previas mergeadas.
 
-### B. Después del push
+### B. Preview
 
-- [ ] PR creada o actualizada.
+- [ ] PR creada o actualizada para la fase vigente.
 - [ ] Preview de Vercel generada para la rama correcta.
 - [ ] URL de preview visible en la PR.
 
@@ -91,13 +90,12 @@ Hacer merge recién si:
 
 Orden recomendado:
 
-1. Push.
-2. PR.
-3. Preview.
-4. Validación preview.
-5. Promote a prod.
-6. Validación prod.
-7. Merge.
+1. PR.
+2. Preview.
+3. Validación preview.
+4. Promote a prod.
+5. Validación prod.
+6. Merge.
 
 ## 4. Validación manual exacta en preview y prod
 
@@ -136,7 +134,6 @@ Si preview pasa, repetir igual en prod.
 
 Esta fase termina bien cuando:
 
-- rama pueda pushearse,
 - preview quede validada,
 - prod quede validada,
 - y la PR quede lista para merge sin dudas operativas.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,140 @@
+# Release humano final — Voca-IA
+
+Estado de esta fase: **listo para release humano**.
+
+Bloqueante actual: **falta push de la rama local por bloqueo SSH**.
+
+## 1. Qué está listo hoy
+
+- Fases 1-5 implementadas localmente.
+- Validación local requerida ejecutable:
+  - `npm test`
+  - `npm run test:smoke`
+  - `npx tsc --noEmit`
+- Documentación operativa lista para hacer release apenas se destrabe el push.
+
+## 2. Push pendiente
+
+Hacer esto apenas vuelva el acceso SSH:
+
+1. Verificar rama actual correcta.
+2. Verificar cambios esperados con `git status`.
+3. Pushear la rama local pendiente al remoto.
+4. Confirmar que el commit local de Fase 4 y los cambios de Fase 5 quedaron en remoto.
+5. Abrir o actualizar la PR.
+6. Publicar comentario de estado usando `docs/pr-comment-phase5.md`.
+
+## 3. Release exacto: preview -> prod -> merge
+
+### A. Antes del push
+
+- [ ] `npm test` verde.
+- [ ] `npm run test:smoke` verde.
+- [ ] `npx tsc --noEmit` verde.
+- [ ] Sin cambios locales inesperados.
+
+### B. Después del push
+
+- [ ] PR creada o actualizada.
+- [ ] Preview de Vercel generada para la rama correcta.
+- [ ] URL de preview visible en la PR.
+
+### C. Validación manual en preview
+
+Usar `tests/smoke/flujo-migracion.smoke.md`.
+
+- [ ] `/` carga y CTA navega a `/questions`.
+- [ ] `/questions` carga preguntas generales.
+- [ ] Ruta feliz termina en `/results`.
+- [ ] `/results` directo muestra fallback usable.
+- [ ] Caso `empate_ramas_desempate` funciona.
+- [ ] Caso `empate_carrera` funciona.
+- [ ] Errores visibles siguen claros.
+- [ ] APIs críticas responden:
+  - [ ] `GET /api/preguntas-generales`
+  - [ ] `POST /api/evaluar-ramas`
+  - [ ] `POST /api/evaluar-carrera`
+
+### D. Go / No-Go para producción
+
+**GO** si se cumple todo:
+
+- [ ] Tests locales en verde.
+- [ ] Smoke manual completo en preview.
+- [ ] Sin errores bloqueantes en preview.
+- [ ] PR con contexto claro para reviewer.
+
+**NO-GO** si pasa algo de esto:
+
+- [ ] Smoke manual incompleto.
+- [ ] Ruta feliz rota.
+- [ ] Fallback de `/results` roto.
+- [ ] APIs críticas fallando.
+- [ ] Empates o errores visibles con regresión.
+
+### E. Paso a producción
+
+- [ ] Promover preview validada a prod en Vercel.
+- [ ] Confirmar URL final correcta.
+- [ ] Repetir smoke manual en prod.
+
+### F. Merge final
+
+Hacer merge recién si:
+
+- [ ] Preview validada.
+- [ ] Producción validada.
+- [ ] Sin rollback en curso.
+- [ ] Reviewer dio ok.
+
+Orden recomendado:
+
+1. Push.
+2. PR.
+3. Preview.
+4. Validación preview.
+5. Promote a prod.
+6. Validación prod.
+7. Merge.
+
+## 4. Validación manual exacta en preview y prod
+
+Checklist mínimo:
+
+1. Entrar a `/`.
+2. Ir a `/questions` desde CTA.
+3. Completar flujo feliz hasta `/results`.
+4. Abrir `/results` sin estado y validar fallback.
+5. Reproducir empate de ramas.
+6. Reproducir empate de carrera.
+7. Validar mensajes de error visibles.
+8. Validar respuesta de APIs críticas.
+
+Si preview pasa, repetir igual en prod.
+
+## 5. Si smoke falla
+
+### Si falla en preview
+
+1. **No promover a prod**.
+2. Dejar comentario en PR con falla exacta.
+3. Corregir en rama.
+4. Revalidar local.
+5. Generar nueva preview.
+
+### Si falla en prod
+
+1. **No mergear** si todavía no se mergeó.
+2. Hacer rollback al deployment estable anterior.
+3. Repetir smoke mínimo para confirmar rollback sano.
+4. Documentar falla y causa probable.
+5. Recién después reintentar release.
+
+## 6. Criterio de salida de esta fase
+
+Esta fase termina bien cuando:
+
+- rama pueda pushearse,
+- preview quede validada,
+- prod quede validada,
+- y la PR quede lista para merge sin dudas operativas.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,5 +1,7 @@
 # Release humano final — Voca-IA
 
+Estado global vigente: `docs/migration-master-plan.md`.
+
 Estado de esta fase: **listo para release humano**.
 
 Bloqueante actual: **falta push de la rama local por bloqueo SSH**.


### PR DESCRIPTION
Closes #7

## Type
- [x] Documentation only

## Summary
- add final release checklist and PR comment template
- add migration master plan and planning index as final planning sources of truth
- update README and production docs to point to release/planning guidance

## Test Plan
- [x] `npm test`
- [x] `npm run test:smoke`
- [x] `npx tsc --noEmit`
- [x] No build executed